### PR TITLE
Use PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW

### DIFF
--- a/src/main/java/org/gridsuite/shortcircuit/server/service/ShortCircuitWorkerService.java
+++ b/src/main/java/org/gridsuite/shortcircuit/server/service/ShortCircuitWorkerService.java
@@ -83,7 +83,7 @@ public class ShortCircuitWorkerService {
     private Network getNetwork(UUID networkUuid, String variantId) {
         Network network;
         try {
-            network = networkStoreService.getNetwork(networkUuid, PreloadingStrategy.COLLECTION);
+            network = networkStoreService.getNetwork(networkUuid, PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW);
             String variant = StringUtils.isBlank(variantId) ? VariantManagerConstants.INITIAL_VARIANT_ID : variantId;
             network.getVariantManager().setWorkingVariant(variant);
         } catch (PowsyblException e) {

--- a/src/test/java/org/gridsuite/shortcircuit/server/ShortCircuitAnalysisControllerTest.java
+++ b/src/test/java/org/gridsuite/shortcircuit/server/ShortCircuitAnalysisControllerTest.java
@@ -164,13 +164,13 @@ public class ShortCircuitAnalysisControllerTest {
         network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, VARIANT_2_ID);
         network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, VARIANT_3_ID);
 
-        given(networkStoreService.getNetwork(NETWORK_UUID, PreloadingStrategy.COLLECTION)).willReturn(network);
+        given(networkStoreService.getNetwork(NETWORK_UUID, PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW)).willReturn(network);
 
         networkForMergingView = new NetworkFactoryImpl().createNetwork("mergingView", "test");
-        given(networkStoreService.getNetwork(NETWORK_FOR_MERGING_VIEW_UUID, PreloadingStrategy.COLLECTION)).willReturn(networkForMergingView);
+        given(networkStoreService.getNetwork(NETWORK_FOR_MERGING_VIEW_UUID, PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW)).willReturn(networkForMergingView);
 
         otherNetworkForMergingView = new NetworkFactoryImpl().createNetwork("other", "test 2");
-        given(networkStoreService.getNetwork(OTHER_NETWORK_FOR_MERGING_VIEW_UUID, PreloadingStrategy.COLLECTION)).willReturn(otherNetworkForMergingView);
+        given(networkStoreService.getNetwork(OTHER_NETWORK_FOR_MERGING_VIEW_UUID, PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW)).willReturn(otherNetworkForMergingView);
 
         network1 = EurostagTutorialExample1Factory.createWithMoreGenerators(new NetworkFactoryImpl());
         network1.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, VARIANT_2_ID);


### PR DESCRIPTION
Using PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW instead of COLLECTION reduces network load duration before short-circuit computation.