### PR TITLE
Add indexes on feeder_results and limit_violations tables

### DIFF
--- a/src/main/java/org/gridsuite/shortcircuit/server/entities/FaultResultEntity.java
+++ b/src/main/java/org/gridsuite/shortcircuit/server/entities/FaultResultEntity.java
@@ -37,13 +37,13 @@ public class FaultResultEntity {
     private double shortCircuitPower;
 
     @ElementCollection
-    @CollectionTable(name = "limit_violations", 
+    @CollectionTable(name = "limit_violations",
             indexes = {@Index(name = "limit_violations_fault_result_idx",
                     columnList = "fault_result_entity_fault_result_uuid")})
     private List<LimitViolationEmbeddable> limitViolations;
 
     @ElementCollection
-    @CollectionTable(name = "feeder_results", 
+    @CollectionTable(name = "feeder_results",
             indexes = {@Index(name = "feeder_results_fault_result_idx",
                     columnList = "fault_result_entity_fault_result_uuid")})
     private List<FeederResultEmbeddable> feederResults;

--- a/src/main/java/org/gridsuite/shortcircuit/server/entities/FaultResultEntity.java
+++ b/src/main/java/org/gridsuite/shortcircuit/server/entities/FaultResultEntity.java
@@ -37,11 +37,15 @@ public class FaultResultEntity {
     private double shortCircuitPower;
 
     @ElementCollection
-    @CollectionTable(name = "limit_violations")
+    @CollectionTable(name = "limit_violations", 
+            indexes = {@Index(name = "limit_violations_fault_result_idx",
+                    columnList = "fault_result_entity_fault_result_uuid")})
     private List<LimitViolationEmbeddable> limitViolations;
 
     @ElementCollection
-    @CollectionTable(name = "feeder_results")
+    @CollectionTable(name = "feeder_results", 
+            indexes = {@Index(name = "feeder_results_fault_result_idx",
+                    columnList = "fault_result_entity_fault_result_uuid")})
     private List<FeederResultEmbeddable> feederResults;
 
 }

--- a/src/main/resources/db/changelog/changesets/changelog_2023-03-31T11:38:24Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_2023-03-31T11:38:24Z.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="bouzolssyl (generated)" id="1680262718004-1">
+        <createIndex indexName="feeder_results_fault_result_idx" tableName="feeder_results">
+            <column name="fault_result_entity_fault_result_uuid"/>
+        </createIndex>
+        <createIndex indexName="limit_violations_fault_result_idx" tableName="limit_violations">
+            <column name="fault_result_entity_fault_result_uuid"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -6,3 +6,6 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_2023-01-13T13:22:26Z.xml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_2023-03-31T11:38:24Z.xml
+      relativeToChangelogFile: true


### PR DESCRIPTION
For perf optim when getting results

ex: with a classical network
**Before**
| nb of shortcircuit results| compute time | store time | get results time |
|--------------|-----------|------------|-----------|
| 1 | 15s | 2s | 2s |
| 5 | 15s | 2s | 3s |
| 10 | 15s | 2s | 5s |

**After**
| nb of shortcircuit results| compute time | store time | get results time |
|--------------|-----------|------------|-----------|
| 1 | 15s | 2s | **1s** |
| 5 | 15s | 2s | **1s** |
| 10 | 15s | 2s | **1s** |