### PR TITLE
Don't log the cancellation exception.

### DIFF
--- a/src/main/java/org/gridsuite/shortcircuit/server/service/ShortCircuitWorkerService.java
+++ b/src/main/java/org/gridsuite/shortcircuit/server/service/ShortCircuitWorkerService.java
@@ -39,6 +39,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static org.gridsuite.shortcircuit.server.service.NotificationService.CANCEL_MESSAGE;
 import static org.gridsuite.shortcircuit.server.service.NotificationService.FAIL_MESSAGE;
 
 /**
@@ -203,6 +204,7 @@ public class ShortCircuitWorkerService {
     private void cleanShortCircuitAnalysisResultsAndPublishCancel(UUID resultUuid, String receiver) {
         resultRepository.delete(resultUuid);
         notificationService.publishStop(resultUuid, receiver);
+        LOGGER.info(CANCEL_MESSAGE + " (resultUuid='{}')", resultUuid);
     }
 
     @Bean
@@ -241,8 +243,8 @@ public class ShortCircuitWorkerService {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } catch (Exception e) {
-                LOGGER.error(FAIL_MESSAGE, e);
                 if (!(e instanceof CancellationException)) {
+                    LOGGER.error(FAIL_MESSAGE, e);
                     notificationService.publishFail(resultContext.getResultUuid(), resultContext.getRunContext().getReceiver(), e.getMessage(), resultContext.getRunContext().getUserId(), resultContext.getRunContext().getBusId());
                     resultRepository.delete(resultContext.getResultUuid());
                 }


### PR DESCRIPTION
Get a consistent implementation with respect to other calculation services, log a cancellation message instead.