### PR TITLE
Remove hashCode() and equals() overrides + clean result entities annotation

### DIFF
--- a/src/main/java/org/gridsuite/shortcircuit/server/entities/FaultResultEntity.java
+++ b/src/main/java/org/gridsuite/shortcircuit/server/entities/FaultResultEntity.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 /**

--- a/src/main/java/org/gridsuite/shortcircuit/server/entities/FaultResultEntity.java
+++ b/src/main/java/org/gridsuite/shortcircuit/server/entities/FaultResultEntity.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -31,7 +32,7 @@ public class FaultResultEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID faultResultUuid;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @Setter
     private ShortCircuitAnalysisResultEntity result;
 
@@ -129,22 +130,6 @@ public class FaultResultEntity {
     public void setFeederResults(List<FeederResultEntity> feederResults) {
         this.feederResults = feederResults;
         feederResults.stream().forEach(feederResultEntity -> feederResultEntity.setFaultResult(this));
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof FaultResultEntity)) {
-            return false;
-        }
-        return faultResultUuid != null && faultResultUuid.equals(((FaultResultEntity) o).getFaultResultUuid());
-    }
-
-    @Override
-    public int hashCode() {
-        return getClass().hashCode();
     }
 
     public double getPositiveMagnitude() {

--- a/src/main/java/org/gridsuite/shortcircuit/server/entities/FeederResultEntity.java
+++ b/src/main/java/org/gridsuite/shortcircuit/server/entities/FeederResultEntity.java
@@ -28,10 +28,7 @@ public class FeederResultEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID feederResultUuid;
 
-    @ManyToOne(
-            cascade = CascadeType.ALL,
-            fetch = FetchType.LAZY
-    )
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fault_result_entity_fault_result_uuid")
     private FaultResultEntity faultResult;
 

--- a/src/main/java/org/gridsuite/shortcircuit/server/entities/ShortCircuitAnalysisResultEntity.java
+++ b/src/main/java/org/gridsuite/shortcircuit/server/entities/ShortCircuitAnalysisResultEntity.java
@@ -30,6 +30,12 @@ public class ShortCircuitAnalysisResultEntity {
     @Column
     private ZonedDateTime writeTimeStamp;
 
+    /*
+    Bidirectional relation is not needed here and is done for performance
+    https://vladmihalcea.com/the-best-way-to-map-a-onetomany-association-with-jpa-and-hibernate/
+    equals() and hashCode() methods are not overrided as the article above recommands it because we use a Set of FaultResultEntity
+    and having a constant hashCode() causes performance issues.
+     */
     @OneToMany(mappedBy = "result", cascade = CascadeType.ALL, orphanRemoval = true)
     @Setter
     private Set<FaultResultEntity> faultResults;

--- a/src/test/java/org/gridsuite/shortcircuit/server/repositories/FaultResultRepositoryTest.java
+++ b/src/test/java/org/gridsuite/shortcircuit/server/repositories/FaultResultRepositoryTest.java
@@ -99,7 +99,7 @@ class FaultResultRepositoryTest {
     void faultResultFilterTest(ShortCircuitAnalysisResultEntity resultEntity, List<ResourceFilter> resourceFilters, List<FaultResultEntity> faultList) {
         Page<FaultResultEntity> faultPage = shortCircuitAnalysisResultRepository.findFaultResultsPage(resultEntity, resourceFilters, Pageable.unpaged(), FaultResultsMode.BASIC);
         assertThat(faultPage.getContent()).extracting("fault.id").describedAs("Check if the IDs of the fault page are correct")
-            .containsExactlyElementsOf(faultList.stream().map(faultResultEntity -> faultResultEntity.getFault().getId()).toList());
+            .containsAll(faultList.stream().map(faultResultEntity -> faultResultEntity.getFault().getId()).toList());
     }
 
     private Stream<Arguments> provideOrEqualsNestedFieldsFilters() {

--- a/src/test/java/org/gridsuite/shortcircuit/server/repositories/FaultResultRepositoryTest.java
+++ b/src/test/java/org/gridsuite/shortcircuit/server/repositories/FaultResultRepositoryTest.java
@@ -99,7 +99,7 @@ class FaultResultRepositoryTest {
     void faultResultFilterTest(ShortCircuitAnalysisResultEntity resultEntity, List<ResourceFilter> resourceFilters, List<FaultResultEntity> faultList) {
         Page<FaultResultEntity> faultPage = shortCircuitAnalysisResultRepository.findFaultResultsPage(resultEntity, resourceFilters, Pageable.unpaged(), FaultResultsMode.BASIC);
         assertThat(faultPage.getContent()).extracting("fault.id").describedAs("Check if the IDs of the fault page are correct")
-            .containsAll(faultList.stream().map(faultResultEntity -> faultResultEntity.getFault().getId()).toList());
+            .containsExactlyInAnyOrderElementsOf(faultList.stream().map(faultResultEntity -> faultResultEntity.getFault().getId()).toList());
     }
 
     private Stream<Arguments> provideOrEqualsNestedFieldsFilters() {


### PR DESCRIPTION
This PR removes the overrides of the equals() and hashCode() methods. During results insertion, we manage Sets cointaining thousands of entities. and having a constant hashCode() causes performance issues.
This PR also cleans (cascade = CascadeType.ALL) property on ManyToOne annotation that is not recommended.

Perfomance comparison - insertion of shortcircuit analysis on a "recollement" : 
on main : 8-9s
on this branch : 3-4s